### PR TITLE
Fixed an error on compilation and better described set up.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .POSIX:
 .PHONY: all clean splitters
 
-CFLAGS := -Wall -Werror $(shell pkg-config --cflags vtk) -D_POSIX_C_SOURCE=200809L
+CFLAGS := -Wall $(shell pkg-config --cflags vtk) $(shell pkg-config --cflags cairo-xlib) -D_POSIX_C_SOURCE=200809L
 LDFLAGS := $(shell pkg-config --libs vtk) -lpthread
 
 SPLITTER_FLAGS := -D_POSIX_C_SOURCE=200809L

--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ To set up adrift you need to create a configuration directory. The directory can
 - splitter
 
 To create the splits file you can read the 'Usage' section of this Readme.
-For the splitter file you can download the splitter from the releases page.
+
 If you compiled adrift, your splitter file will be in ./splitters/sar_split, rename it to splitter and move it to the directory.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ These can be given by running the following command as root:
 
 ## Set up
 
-To set up adrift you need to create a configuration directory. The directory can have any name, but the name "portal2" or the category of the speedrun. The directory should contain the files 
+To set up adrift you need to create a configuration directory. The directory can have any name, but the name "portal2" or the category of the speedrun. The directory should contain the files below 
 - splits 
 - splitter
-Both of which are documented in this readme section. The directory can also contain a config file.
+
+To create the splits file you can read the 'Usage' section of this Readme.
+For the splitter file you can download the splitter from the releases page.
+If you compiled adrift, your splitter file will be in ./splitters/sar_split, rename it to splitter and move it to the directory.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,10 @@ requires ptrace privileges to work, as it must read Portal 2's memory.
 These can be given by running the following command as root:
 
 	setcap cap_sys_ptrace=eip ./splitter
+
+## Set up
+
+To set up adrift you need to create a configuration directory. The directory can have any name, but the name "portal2" or the category of the speedrun. The directory should contain the files 
+- splits 
+- splitter
+Both of which are documented in this readme section. The directory can also contain a config file.

--- a/main.c
+++ b/main.c
@@ -122,6 +122,7 @@ int main(int argc, char **argv) {
 	ssize_t nsplits = read_splits_file("splits", &splits);
 
 	if (nsplits == -1) {
+		fputs("Error: Missing a splits file.\n", stderr);
 		return 1;
 	}
 


### PR DESCRIPTION
This pull request changes the Makefile's CFLAGS to include cairo-xlib, this is to fix an issue which is caused by Gentoo, since cairo.h in Gentoo is in /usr/include/cairo/cairo.h.
An error is outputted onto the terminal when a splits file is missing.
Set up is also documented.

If you want any changes be sure to ask.
Have a nice day mlugg :)